### PR TITLE
Use ES5 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const isUrl = require('is-url')
-const queryString = require('query-string')
-const normalizeUrl = require('normalize-url')
+var isUrl = require('is-url')
+var queryString = require('query-string')
+var normalizeUrl = require('normalize-url')
 
-module.exports = (queryParam, url) => {
+module.exports = function(queryParam, url) {
   if (typeof queryParam !== 'string' || typeof url !== 'string') {
     throw new TypeError('get-query-param expected two strings')
   }
 
-  const fullUrl = /^\//.test(url) ? `foo.bar${url}` : url
-  const normalizedUrl = normalizeUrl(fullUrl)
+  var fullUrl = /^\//.test(url) ? `foo.bar${url}` : url
+  var normalizedUrl = normalizeUrl(fullUrl)
 
   if (!isUrl(normalizedUrl)) { return }
 
-  const parsed = queryString.parse(normalizedUrl.split('?')[1])
+  var parsed = queryString.parse(normalizedUrl.split('?')[1])
 
   return parsed[queryParam]
 }


### PR DESCRIPTION
We recently had a bug in production due to this library. We use this library on the frontend and we don't transpile the dependencies because it's best practice that npm packages are production ready with ES5 syntax.  The error was that many browsers gives an exception because of the usage of the `const` keyword.

Many larger libs transpile their code through babel and that could be an option for this library aswell. But because this code is so short I did the easiest thing and just translated the code to ES5 directly.